### PR TITLE
Fix space leak in ioFeat

### DIFF
--- a/Test/Feat/Access.hs
+++ b/Test/Feat/Access.hs
@@ -97,7 +97,7 @@ ioFeat :: [(Integer,[a])] -> Report a -> IO ()
 ioFeat vs f = go vs 0 0 where
   go ((c,xs):xss) s tot = do
     putStrLn $ "--- Testing "++show c++" values at size " ++ show s
-    mapM f xs
+    mapM_ f xs
     go xss (s+1) (tot + c)
   go []           s tot = putStrLn $ "--- Done. Tested "++ show tot++" values"
 


### PR DESCRIPTION
`ioFeat` contains a call to `mapM` with a potentially very long list, which leads to a space leak, as the result list is retained until the end of the computation.

You can demonstrate the problem by executing the following code:

```
module Main where

import Test.Feat

main = featCheck 45 ((\_ -> True) :: [Bool] -> Bool)
```

With the current version of testing-feat, the code requires over 200MB of memory, whereas only 2 MB is consumed if we replace`mapM` with `mapM_` in `ioFeat`, as proposed in this PR.


