### PR TITLE
Update for GHC 8.4

### DIFF
--- a/Test/Feat/Finite.hs
+++ b/Test/Feat/Finite.hs
@@ -2,6 +2,7 @@
 module Test.Feat.Finite (Finite (..), Index, fromFinite, finFin) where
 
 import Control.Applicative
+import Data.Semigroup
 import Data.Monoid
 
 type Index = Integer
@@ -29,6 +30,9 @@ instance Applicative Finite where
 instance Alternative Finite where
   empty = finEmpty
   (<|>) = finUnion
+
+instance Semigroup (Finite a) where
+  (<>) = finUnion
 
 instance Monoid (Finite a) where
   mempty = finEmpty

--- a/testing-feat.cabal
+++ b/testing-feat.cabal
@@ -47,3 +47,5 @@ Library
     QuickCheck > 2 && < 3,
     size-based < 0.2,
     testing-type-modifiers < 0.2
+  if impl(ghc < 8.0)
+    Build-depends: semigroups < 0.19


### PR DESCRIPTION
Add `Semigroup` instance and dependency for GHC < 8.0.